### PR TITLE
Bug in option -e or -l

### DIFF
--- a/cve-2017-0199_toolkit.py
+++ b/cve-2017-0199_toolkit.py
@@ -194,11 +194,8 @@ def main(argv):
 	    print "Running exploit mode (Deliver Custom HTA) - waiting for victim to connect"
             exploitation()
 	    sys.exit()
-        if (len(payloadurl)<1):
-            print 'Usage: python '+sys.argv[0]+' -h'
-            sys.exit()
-        if (len(payloadlocation)<1):
-            print 'Usage: python '+sys.argv[0]+' -h'
+        if (len(payloadurl) < 1 and len(payloadlocation) < 1):
+            print 'Usage: python ' + sys.argv[0] + ' -h'
             sys.exit()
         print "Running exploit mode (Deliver HTA + Payload) - waiting for victim to connect"
         exploitation()


### PR DESCRIPTION
A bug occur when we choose an option between -e or -l.
If you specify one of them, the helper is prompting but in fact you have to choose only one option: local or remote payload delivery.